### PR TITLE
Basic implementation of strawman ABC/parser registry, argparse group

### DIFF
--- a/mailbag/__init__.py
+++ b/mailbag/__init__.py
@@ -4,18 +4,27 @@
 __version__ = "0.0.1"
 
 
-from bagit import _make_parser
+from bagit import _make_parser, Bag
 from gooey import Gooey
+
+from .parser import EmailFormatParser
+
+print(EmailFormatParser.registry)
 
 bagit_parser = _make_parser()
 bagit_parser.description = f"Mailbag ({bagit_parser.description})"
+mailbagit_args = bagit_parser.add_argument_group("Mailbag")
+# add mailbag-specific args here
+mailbagit_args.add_argument("--foo", help="The foo argument, you know, that one")
 
 def cli():
     bagit_parser.parse_args()
+    # do the thing
 
 @Gooey
 def gui():
     bagit_parser.parse_args()
+    #do the thing
 
 class Mailbag:
     def __init__(self):

--- a/mailbag/__init__.py
+++ b/mailbag/__init__.py
@@ -7,7 +7,7 @@ __version__ = "0.0.1"
 from bagit import _make_parser, Bag
 from gooey import Gooey
 
-from .parser import EmailFormatParser
+from mailbag.parser import EmailFormatParser
 
 print(EmailFormatParser.registry)
 

--- a/mailbag/parser.py
+++ b/mailbag/parser.py
@@ -1,0 +1,44 @@
+from os import listdir
+from os.path import dirname, basename, isfile, join
+
+from abc import ABC, abstractmethod
+class EmailFormatParser(ABC):
+    """EmailFormatParser - abstract base class and registry for concrete format parsers
+
+    This class serves two purposes.  Firstly, it serves as an abstract base class, defining
+    the methods and properties required by a parser that can parse data out of a particular
+    on-disk email storage format for use by Mailbag.
+
+    Secondly, it serves as a registry of such formats, with the goal of allowing new formats to
+    be implemented in a "plug-in" fashion.  Any class subclassing this one, with the expected
+    properties and a class variable "parser_name" will be registered on this class and thus usable
+    by the software."""
+
+    # Registry of parsers, key = cls.parser_name, value = cls
+    registry = {}
+
+    def __init_subclass__(cls, **kwargs):
+        """Enforce parser_name attribute on subclasses, register them"""
+        if not hasattr(cls, 'parser_name'):
+            raise RuntimeError("EmailFormatParser subclass must have `parser_name` attribute")
+
+        super().__init_subclass__(**kwargs)
+        __class__.registry[cls.parser_name] = cls
+
+    @abstractmethod
+    def parse(self, *args, **kwargs):
+        """Implement a parse method that processes a concrete mail format (e.g. mbox, pst) and
+        returns the information needed by mailbag to process that format"""
+        pass
+
+def import_parsers():
+    parser_dir = join(dirname(__file__), 'parsers')
+
+    for filename in listdir(parser_dir):
+        module = basename(filename)
+
+        if module.startswith('_') or not isfile(join(parser_dir, filename)):
+            continue
+        __import__('mailbag.parsers.' + module[:-3], globals(), locals())
+
+import_parsers()

--- a/mailbag/parsers/example.py
+++ b/mailbag/parsers/example.py
@@ -1,0 +1,10 @@
+# This is an example parser, meant to show how
+# to hook up a real parser
+
+# Does nothing currently
+from mailbag.parser import EmailFormatParser
+class ExampleParser(EmailFormatParser):
+    parser_name = 'example'
+
+    def parse(self, *args, **kwargs):
+        print("Parsity parse")

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/UAlbanyArchives/mailbag",
-    packages=setuptools.find_packages(exclude=("tests")),
+    packages=setuptools.find_namespace_packages(exclude=("tests")),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
 ## Type of Contribution

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Adds a class MailFormatParser which serves as an abstract base class and a registry for parsers, and a dummy parser as an example.

## Link to issue?

Relates to #19 
...

- [ ] Issue closed
- [x] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [ ] For new components, make sure you are requesting to a separate branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [ ] All tests pass

#### How has this been tested?
**Operating System:** …
**Python Version:** …

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbag/blob/main/LICENSE).
