### PR TITLE
Limit input and derivatives arguments to available formats

### DIFF
--- a/mailbag/__init__.py
+++ b/mailbag/__init__.py
@@ -39,9 +39,12 @@ bagit_parser.description = f"Mailbag ({bagit_parser.description})"
 mailbagit_args = bagit_parser.add_argument_group("Mailbag arguments")
 mailbagit_options = bagit_parser.add_argument_group("Mailbag options")
 
+input_types = list(EmailAccount.registry.keys())
+derivative_types = list(Derivative.registry.keys())
+
 # add mailbag-specific required args here
-mailbagit_args.add_argument("-i", "--input", required=True, help="input type MBOX/PST/IMAP/EML/PDF/MSG", nargs=None)
-mailbagit_args.add_argument("-d", "--derivatives", required=True, help="derivative type(s) MBOX/PST/EML/PDF/WARC", nargs='+')
+mailbagit_args.add_argument("-i", "--input", required=True, help=f"type of mailbox to be bagged", choices=input_types, nargs=None)
+mailbagit_args.add_argument("-d", "--derivatives", choices=derivative_types, required=False, help=f"types of derivatives to create before bagging", nargs='+')
 
 # add mailbag-specific optional args here
 mailbagit_options.add_argument("--imap_host", help="the host for creating a mailbag from an IMAP connection", nargs=None)


### PR DESCRIPTION
 ## Type of Contribution

- [x] Feature request

## What does this implement/fix? Explain your changes.

Gets the keys of the EmailAccount and Derivatives registries and uses them to populate the `choices` argument for the --input and --derivative arguments respectively. This way we won't have to maintain them, and they'll remain accurate when run by someone who's added plugins.

## Link to issue?

#76

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [x] All tests pass

#### How has this been tested?
**Operating System:** Windows 10, Ubuntu LTS 20.04.3
**Python Version:** 3.9.7

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbag/blob/main/LICENSE).
