### PR TITLE
Regularizes format arguments, fixes tests, makes PST conditional

### DIFF
--- a/mailbag/controller.py
+++ b/mailbag/controller.py
@@ -15,33 +15,33 @@ log = get_logger()
 
 class Controller:
     """Controller - Main controller"""
-    
+
     def __init__(self, args):
         self.args = args
-    
+
     @property
     def format_map(self):
         return EmailAccount.registry
 
     def read(self, input, directory):
-        
+
         format = self.format_map[input]
-        
+
 
         if len(directory) > 1:
-            # checks that mailbag was only given one directory as input. 
-            # bagit-python loops through all directory args, and we may have to 
+            # checks that mailbag was only given one directory as input.
+            # bagit-python loops through all directory args, and we may have to
             # handle multiple inputs at some point but for now just raise an error.
             log.error("Mailbag currently only reads one input source.")
             raise ValueError("Mailbag currently only reads one input source.")
         else:
             path = directory[0]
             self.reader(format,path)
-    
+
     def reader(self, format, path):
-        data = format(self.args.dry_run, self.args.mailbag_name, path)
+        data = format(path, self.args)
         messages = data.messages()
-        
+
         for message in messages:
             log.debug(message.to_struct())
 

--- a/mailbag/email_account.py
+++ b/mailbag/email_account.py
@@ -27,7 +27,7 @@ class EmailAccount(ABC):
         __class__.registry[cls.format_name] = cls
 
     @abstractmethod
-    def __init__(self, target_account, **kwargs):
+    def __init__(self, target_account, args, **kwargs):
         """Implement a method that finds and sets up an account so that `account_data` and `messages` can
 be called on it."""
         pass

--- a/mailbag/formats/example.py
+++ b/mailbag/formats/example.py
@@ -7,7 +7,7 @@ from mailbag.models import Email
 class ExampleAccount(EmailAccount):
     format_name = 'example'
 
-    def __init__(self, target_account, **kwargs):
+    def __init__(self, target_account, args, **kwargs):
         print("Parsity parse")
         # code goes here to set up mailbox and pull out any relevant account_data
         account_data = {}

--- a/mailbag/formats/mbox.py
+++ b/mailbag/formats/mbox.py
@@ -13,25 +13,25 @@ class Mbox(EmailAccount):
     """Mbox - This concrete class parses mbox file format"""
     format_name = 'mbox'
 
-    def __init__(self, dry_run, mailbag_name, target_account, **kwargs):
+    def __init__(self, target_account, args, **kwargs):
         log.debug("Parsity parse")
         # code goes here to set up mailbox and pull out any relevant account_data
         account_data = {}
 
         self.file = target_account
-        self.dry_run = dry_run
-        self.mailbag_name = mailbag_name
-        log.info("Reading : ", File=self.file)    
+        self.dry_run = args.dry_run
+        self.mailbag_name = args.mailbag_name
+        log.info("Reading : ", File=self.file)
 
     def account_data(self):
         return account_data
- 
+
     def messages(self):
-           
+
         files = glob.glob(os.path.join(self.file, "**", "*.mbox"), recursive=True)
         for filePath in files:
             subFolder = helper.emailFolder(self.file,filePath)
-            
+
             data = mailbox.mbox(filePath)
             for mail in data.itervalues():
                 try:

--- a/mailbag/formats/msg.py
+++ b/mailbag/formats/msg.py
@@ -12,21 +12,21 @@ class MSG(EmailAccount):
     """MSG - This concrete class parses msg file format"""
     format_name = 'msg'
 
-    def __init__(self, dry_run, mailbag_name, target_account, **kwargs):
+    def __init__(self, target_account, args, **kwargs):
         log.debug("Parsity parse")
         # code goes here to set up mailbox and pull out any relevant account_data
         account_data = {}
 
         self.file = target_account
-        self.dry_run = dry_run
-        self.mailbag_name = mailbag_name
+        self.dry_run = args.dry_run
+        self.mailbag_name = args.mailbag_name
         log.info("Reading :",File=self.file)
 
     def account_data(self):
         return account_data
 
     def messages(self):
-        
+
         files = glob.glob(os.path.join(self.file, "**", "*.msg"), recursive=True)
         for filePath in files:
             subFolder = helper.emailFolder(self.file,filePath)
@@ -42,7 +42,7 @@ class MSG(EmailAccount):
                 Subject=mail.subject,
                 Body=mail.body
             )
-            
+
             # Make sure the MSG file is closed
             mail.close()
             # Move MBOX to new mailbag directory structure

--- a/mailbag/formats/pst.py
+++ b/mailbag/formats/pst.py
@@ -5,67 +5,71 @@ from email import parser
 from mailbag.email_account import EmailAccount
 from mailbag.models import Email
 
+# only create format if pypff is successfully importable -
+# pst is not supported otherwise
+skip_registry = False
+try:
+    import pypff
+except:
+    skip_registry = True
+
 log = get_logger()
 
+if not skip_registry:
+    class PST(EmailAccount):
+        # pst - This concrete class parses PST file format
+        format_name = 'pst'
 
-class PST(EmailAccount):
-    # pst - This concrete class parses PST file format
-    format_name = 'pst'
+        def __init__(self,  target_account, args, **kwargs):
+            log.debug("Parsity parse")
+            # code goes here to set up mailbox and pull out any relevant account_data
 
-    def __init__(self, dry_run, mailbag_name, target_account, **kwargs):
-        log.debug("Parsity parse")
-        # code goes here to set up mailbox and pull out any relevant account_data
+            self.file = target_account
+            log.info("Reading :",File=self.file)
 
-        self.file = target_account
-        log.info("Reading :",File=self.file)
+        def account_data(self):
+            return account_data
 
-    def account_data(self):
-        return account_data
-
-    def folders(self, folder, path):
-        # recursive function that calls itself on any subfolders and
-        # returns a generator of messages
-        # path is a list that you can create the filepath with join()
-        if folder.number_of_sub_folders:
-            path.append(folder.name)
-            for folder_index in range(folder.number_of_sub_folders):
-                subfolder = folder.get_sub_folder(folder_index)
-                yield from self.folders(subfolder, path)
-        elif folder.number_of_sub_messages:
-            path.append(folder.name)
-            for index in range(folder.number_of_sub_messages):
-                messageObj = folder.get_sub_message(index)
-                headerParser = parser.HeaderParser()
-                headers = headerParser.parsestr(messageObj.transport_headers)
-                message = Email(
-                    Message_ID=headers['Message-ID'],
-                    Email_Folder=join(*path),
-                    Date=headers["Date"],
-                    From=headers["From"],
-                    To=headers["To"],
-                    Cc=headers["To"],
-                    Bcc=headers["Bcc"],
-                    Subject=headers["Subject"],
-                    Content_Type=headers["Content-Type"]
-                )
-                log.debug(message.to_struct())
-                yield message
-        else:
-            # gotta return empty directory to controller somehow
-            log.error("??--> " + folder.name)
-
-    def messages(self):
-        # only import libpff when PST is selected as the input format
-        # this way it won't be required for parsing other formats
-        import pypff
-
-        pst = pypff.file()
-        pst.open(self.file)
-        root = pst.get_root_folder()
-        count = 0
-        for folder in root.sub_folders:
+        def folders(self, folder, path):
+            # recursive function that calls itself on any subfolders and
+            # returns a generator of messages
+            # path is a list that you can create the filepath with join()
             if folder.number_of_sub_folders:
-                return self.folders(folder, [])
+                path.append(folder.name)
+                for folder_index in range(folder.number_of_sub_folders):
+                    subfolder = folder.get_sub_folder(folder_index)
+                    yield from self.folders(subfolder, path)
+            elif folder.number_of_sub_messages:
+                path.append(folder.name)
+                for index in range(folder.number_of_sub_messages):
+                    messageObj = folder.get_sub_message(index)
+                    headerParser = parser.HeaderParser()
+                    headers = headerParser.parsestr(messageObj.transport_headers)
+                    message = Email(
+                        Message_ID=headers['Message-ID'],
+                        Email_Folder=join(*path),
+                        Date=headers["Date"],
+                        From=headers["From"],
+                        To=headers["To"],
+                        Cc=headers["To"],
+                        Bcc=headers["Bcc"],
+                        Subject=headers["Subject"],
+                        Content_Type=headers["Content-Type"]
+                    )
+                    log.debug(message.to_struct())
+                    yield message
             else:
                 # gotta return empty directory to controller somehow
                 log.error("??--> " + folder.name)
+
+        def messages(self):
+            pst = pypff.file()
+            pst.open(self.file)
+            root = pst.get_root_folder()
+            count = 0
+            for folder in root.sub_folders:
+                if folder.number_of_sub_folders:
+                    return self.folders(folder, [])
+                else:
+                    # gotta return empty directory to controller somehow
+                    log.error("??--> " + folder.name)

--- a/tests/test_Controller.py
+++ b/tests/test_Controller.py
@@ -1,14 +1,19 @@
 import pytest
 import os
 from mailbag.controller import Controller
+from mailbag.email_account import EmailAccount
 from mailbag.models import Email
 from mailbag.formats import mbox, msg, pst
+from argparse import Namespace
+
+@pytest.fixture
+def cli_args():
+    return Namespace(dry_run=False, mailbag_name="New_Mailbag")
 
 
-def test_reader_Mbox():
-    args = {"dry_run": False, "mailbag_name": "New_Mailbag"}
-    c = Controller(args)
-    format, path = mbox.Mbox, os.path.join("data", "sample1.mbox")
+def test_reader_Mbox(cli_args):
+    c = Controller(cli_args)
+    format, path = EmailAccount.registry['mbox'], os.path.join("data", "sample1.mbox")
     data = c.reader(format, path)
 
     expected = []
@@ -33,10 +38,9 @@ def test_reader_Mbox():
         assert m == expected[id]
 
 
-def test_reader_MSG():
-    args = {"dry_run": False, "mailbag_name": "New_Mailbag"}
-    c = Controller(args)
-    format, path = msg.MSG, os.path.join("data", "sample1.msg")
+def test_reader_MSG(cli_args):
+    c = Controller(cli_args)
+    format, path = EmailAccount.registry['msg'], os.path.join("data", "sample1.msg")
     data = c.reader(format, path)
 
     expected = []
@@ -51,10 +55,11 @@ def test_reader_MSG():
         assert m == expected[id]
 
 
-def test_reader_PST():
-    args = {"dry_run": False, "mailbag_name": "New_Mailbag"}
-    c = Controller(args)
-    format, path = pst.PST, os.path.join("data", "outlook2019_MSO_16.0.10377.20023_64-bit.pst")
+def test_reader_PST(cli_args):
+    if 'pst' not in EmailAccount.registry:
+        raise pytest.skip("PST format not installed")
+    c = Controller(cli_args)
+    format, path = EmailAccount.registry['pst'], os.path.join("data", "outlook2019_MSO_16.0.10377.20023_64-bit.pst")
     data = c.reader(format, path)
 
     expected =[]
@@ -80,7 +85,7 @@ def test_organizeFileStructure():
     args = {}
     c = Controller(args)
     c.organizeFileStructure(False, 'faculty', 'msg', ['data'])
-    
+
     # Assumes data/sample1.msg file exists
     assert os.path.exists(os.path.join('data', 'faculty', 'data', 'msg', 'sample1.msg')) is True
 """

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,12 +1,18 @@
 from mailbag.controller import Controller
 from mailbag.models import Email
+from argparse import Namespace
+from mailbag.email_account import EmailAccount
 import mailbag
 import pytest
 import os
 
+# This is a mock object representing the args returned from argparse/Gooey
+@pytest.fixture
+def cli_args():
+    return Namespace(dry_run=False, mailbag_name="New_Mailbag")
 
-def test_Mbox():
-    data = mailbag.formats.mbox.Mbox(False, "New_Mailbag", os.path.join("data", "sample1.mbox")).messages()
+def test_Mbox(cli_args):
+    data = EmailAccount.registry['mbox'](os.path.join("data", "sample1.mbox"), cli_args).messages()
 
     expected = []
     expected.append(Email(
@@ -30,8 +36,8 @@ def test_Mbox():
         assert m == expected[id]
 
 
-def test_MSG():
-    data = mailbag.formats.msg.MSG(False, "New_Mailbag", os.path.join("data", "sample1.msg")).messages()
+def test_MSG(cli_args):
+    data = EmailAccount.registry['msg'](os.path.join("data", "sample1.msg"), cli_args).messages()
 
     expected = []
     expected.append(Email(
@@ -45,8 +51,11 @@ def test_MSG():
         assert m == expected[id]
 
 
-def test_PST():
-    data = mailbag.formats.pst.PST(False, "New_Mailbag", os.path.join("data", "outlook2019_MSO_16.0.10377.20023_64-bit.pst")).messages()
+def test_PST(cli_args):
+    if not 'pst' in EmailAccount.registry:
+        raise pytest.skip("PST not installed, cannot test")
+
+    data = EmailAccount.registry['pst'](os.path.join("data", "outlook2019_MSO_16.0.10377.20023_64-bit.pst"), cli_args).messages()
 
     expected = []
     expected.append(Email(


### PR DESCRIPTION
The commit contains the following improvements to existing code

- All formats now take the following signature:
  def __init__(target_account, args, **kwargs)

- PST format now will not register itself if unable to import pypff

- Existing tests work, and PST format tests will be skipped if pypff is
not installed

 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

- All formats now take the following signature:
  def __init__(target_account, args, **kwargs)

- PST format now will not register itself if unable to import pypff

- Existing tests work, and PST format tests will be skipped if pypff is
not installed

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [x] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** Windows 10
**Python Version:** 3.9.7

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbag/blob/main/LICENSE).
