### PR TITLE
Parsers cleanup

### DIFF
--- a/mailbag/controller.py
+++ b/mailbag/controller.py
@@ -83,7 +83,7 @@ class Controller:
 
             #Generate derivatives
             for d in derivatives:
-                d.do_task_per_message(message, self.args)
+                d.do_task_per_message(message, self.args, mailbag_dir)
 
         # append any remaining csv portions < 100000
         csv_data.append(csv_portion)

--- a/mailbag/controller.py
+++ b/mailbag/controller.py
@@ -48,8 +48,8 @@ class Controller:
         csv_dir = os.path.join(parent_dir, self.args.mailbag_name)
 
         #Setting up mailbag.csv
-        header = ['Mailbag-Message-ID', 'Message_ID', 'Email_Folder', 'Original_Filename','Date', 'From', 'To', 'Cc', 'Bcc', 'Subject',
-                  'Content_Type', 'Error']
+        header = ['Error', 'Mailbag-Message-ID', 'Message-ID', 'Message-Path', 'Original-Filename','Date', 'From', 'To', 'Cc', 'Bcc', 'Subject',
+                  'Content_Type']
         csv_data = []
         mailbag_message_id = 0
         csv_portion_count = 0
@@ -71,14 +71,14 @@ class Controller:
                 csv_portion = []
                 csv_portion.append(header)
                 csv_portion.append(
-                    [message.Mailbag_Message_ID, message.Message_ID, message.Email_Folder, message.Original_Filename, message.Date, message.From,
-                     message.To, message.Cc,message.Bcc, message.Subject, message.Content_Type, message.Error])
+                    [" ".join(message.Error), message.Mailbag_Message_ID, message.Message_ID, message.Message_Path, message.Original_Filename, message.Date, message.From,
+                     message.To, message.Cc,message.Bcc, message.Subject, message.Content_Type])
                 csv_portion_count = 0
             #if count is less than 100000 , appending the messages in one list
             else:
                 csv_portion.append(
-                    [message.Mailbag_Message_ID, message.Message_ID, message.Email_Folder, message.Original_Filename, message.Date, message.From,
-                     message.To, message.Cc,message.Bcc, message.Subject, message.Content_Type, message.Error])
+                    [" ".join(message.Error), message.Mailbag_Message_ID, message.Message_ID, message.Message_Path, message.Original_Filename, message.Date, message.From,
+                     message.To, message.Cc,message.Bcc, message.Subject, message.Content_Type])
             csv_portion_count += 1
 
             #Generate derivatives

--- a/mailbag/controller.py
+++ b/mailbag/controller.py
@@ -48,7 +48,7 @@ class Controller:
         csv_dir = os.path.join(parent_dir, self.args.mailbag_name)
 
         #Setting up mailbag.csv
-        header = ['Mailbag-Message-ID', 'Message_ID', 'Email_Folder', 'Date', 'From', 'To', 'Cc', 'Bcc', 'Subject',
+        header = ['Mailbag-Message-ID', 'Message_ID', 'Email_Folder', 'Original_Filename','Date', 'From', 'To', 'Cc', 'Bcc', 'Subject',
                   'Content_Type', 'Error']
         csv_data = []
         mailbag_message_id = 0
@@ -71,13 +71,13 @@ class Controller:
                 csv_portion = []
                 csv_portion.append(header)
                 csv_portion.append(
-                    [message.Mailbag_Message_ID, message.Message_ID, message.Email_Folder, message.Date, message.From,
+                    [message.Mailbag_Message_ID, message.Message_ID, message.Email_Folder, message.Original_Filename, message.Date, message.From,
                      message.To, message.Cc,message.Bcc, message.Subject, message.Content_Type, message.Error])
                 csv_portion_count = 0
             #if count is less than 100000 , appending the messages in one list
             else:
                 csv_portion.append(
-                    [message.Mailbag_Message_ID, message.Message_ID, message.Email_Folder, message.Date, message.From,
+                    [message.Mailbag_Message_ID, message.Message_ID, message.Email_Folder, message.Original_Filename, message.Date, message.From,
                      message.To, message.Cc,message.Bcc, message.Subject, message.Content_Type, message.Error])
             csv_portion_count += 1
 

--- a/mailbag/derivatives/eml.py
+++ b/mailbag/derivatives/eml.py
@@ -19,7 +19,7 @@ class ExampleDerivative(Derivative):
     derivative_name = 'eml'
 
     def __init__(self,email_account, **kwargs):
-        print("Setup account")
+        log.debug("Setup account")
         super()
 
     def do_task_per_account(self):

--- a/mailbag/derivatives/eml.py
+++ b/mailbag/derivatives/eml.py
@@ -12,12 +12,13 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email import generator
 from mailbag.derivative import Derivative
-#from mailbag.controller import Controller
+from mailbag.controller import Controller
 import mailbag.helper as helper
 
 log = get_logger()
 class ExampleDerivative(Derivative):
     derivative_name = 'eml'
+    derivative_format = 'eml'
 
     def __init__(self,email_account, **kwargs):
         log.debug("Setup account")
@@ -42,12 +43,14 @@ class ExampleDerivative(Derivative):
         msg['Cc'] = message.Cc
         msg['Bcc'] = message.Bcc
         msg.attach(part)
-        new_path = os.path.join(out_dir, "data")
+        norm_dir=helper.normalizePath(out_dir)
 
-        log.debug("Writing EML to " + str(new_path))
-        if self.args.dry_run:
-            outfile_name = os.path.join(new_path, "derivative.eml")
+        log.debug("Writing EML to " + str(norm_dir))
+        if not args.dry_run:
+            outfile_name = os.path.join(out_dir,str(message.Mailbag_Message_ID) + "." + self.derivative_format)
             norm_filename = helper.normalizePath(outfile_name)
+            if not os.path.isdir(norm_dir):
+                os.makedirs(norm_dir)
             with open(norm_filename,'w') as outfile:
                 gen = generator.Generator(outfile)
                 gen.flatten(msg)

--- a/mailbag/derivatives/eml.py
+++ b/mailbag/derivatives/eml.py
@@ -25,7 +25,7 @@ class ExampleDerivative(Derivative):
     def do_task_per_account(self):
         print(self.account.account_data())
 
-    def do_task_per_message(self, message, args):
+    def do_task_per_message(self, message, args, mailbag_dir):
 
         html=message.HTML_Body
         part = MIMEText(html,'html')
@@ -36,7 +36,7 @@ class ExampleDerivative(Derivative):
         msg['Cc'] = message.Cc
         msg['Bcc'] = message.Bcc
         msg.attach(part)
-        new_path = os.path.join(args.directory,args.mailbag_name,"data")
+        new_path = os.path.join(mailbag_dir, "data")
 
         log.debug("Writing EML to " + str(new_path))
         if self.args.dry_run:

--- a/mailbag/derivatives/eml.py
+++ b/mailbag/derivatives/eml.py
@@ -13,6 +13,7 @@ from email.mime.text import MIMEText
 from email import generator
 from mailbag.derivative import Derivative
 #from mailbag.controller import Controller
+import mailbag.helper as helper
 
 log = get_logger()
 class ExampleDerivative(Derivative):
@@ -45,8 +46,9 @@ class ExampleDerivative(Derivative):
 
         log.debug("Writing EML to " + str(new_path))
         if self.args.dry_run:
-            outfile_name = os.path.join(new_path,"derivative.eml")
-            with open(outfile_name,'w') as outfile:
+            outfile_name = os.path.join(new_path, "derivative.eml")
+            norm_filename = helper.normalizePath(outfile_name)
+            with open(norm_filename,'w') as outfile:
                 gen = generator.Generator(outfile)
                 gen.flatten(msg)
 

--- a/mailbag/derivatives/eml.py
+++ b/mailbag/derivatives/eml.py
@@ -27,6 +27,11 @@ class ExampleDerivative(Derivative):
 
     def do_task_per_message(self, message, args, mailbag_dir):
 
+        if message.Message_Path is None:
+            out_dir = os.path.join(mailbag_dir, self.derivative_format)
+        else:
+            out_dir = os.path.join(mailbag_dir, self.derivative_format, message.Message_Path)
+
         html=message.HTML_Body
         part = MIMEText(html,'html')
         msg = MIMEMultipart('alternative')
@@ -36,7 +41,7 @@ class ExampleDerivative(Derivative):
         msg['Cc'] = message.Cc
         msg['Bcc'] = message.Bcc
         msg.attach(part)
-        new_path = os.path.join(mailbag_dir, "data")
+        new_path = os.path.join(out_dir, "data")
 
         log.debug("Writing EML to " + str(new_path))
         if self.args.dry_run:

--- a/mailbag/derivatives/example.py
+++ b/mailbag/derivatives/example.py
@@ -16,7 +16,7 @@ class ExampleDerivative(Derivative):
     def do_task_per_account(self):
         print(self.account.account_data())
 
-    def do_task_per_message(self, message, args):
+    def do_task_per_message(self, message, args, mailbag_dir):
         if message.Message_ID:
             log.debug(message.Message_ID.strip())
         else:

--- a/mailbag/derivatives/html.py
+++ b/mailbag/derivatives/html.py
@@ -19,22 +19,31 @@ class HtmlDerivative(Derivative):
 
     def do_task_per_message(self, message, args, mailbag_dir):
 
-        if message.Email_Folder is None:
+        if message.Message_Path is None:
             out_dir = os.path.join(mailbag_dir, self.derivative_format)
         else:
-            out_dir = os.path.join(mailbag_dir, self.derivative_format, message.Email_Folder)
-        filename = os.path.join(out_dir, str(message.Mailbag_Message_ID) + "." + self.derivative_format)
+            out_dir = os.path.join(mailbag_dir, self.derivative_format, message.Message_Path)
+        filename = os.path.join(out_dir, str(message.Mailbag_Message_ID))
 
-        if message.HTML_Body is None and message.Body is None:
-            log.warn("Error writing html derivative for " + str(message.Mailbag_Message_ID))
-        else:
-            log.debug("Writing html derivative to " + filename)
-            if not args.dry_run:
-                if not os.path.isdir(out_dir):
-                    os.makedirs(out_dir)
-                with open(filename, "w") as f:
-                    if message.HTML_Body is None:
-                        f.write(message.Body)
-                    else:
-                        f.write(message.HTML_Body)
-                    f.close()
+        log.debug("Writing html derivative to " + filename)
+        if not args.dry_run:
+            if not os.path.isdir(out_dir):
+                os.makedirs(out_dir)
+            if message.HTML_Bytes:
+                with open(filename + ".html", "wb") as f:
+                    f.write(message.HTML_Bytes)
+                f.close()
+            elif message.HTML_Body:
+                with open(filename + ".html", "w") as f:
+                    f.write(message.HTML_Body)
+                f.close()
+            elif message.Text_Bytes:
+                with open(filename + ".txt", "wb") as f:
+                    f.write(message.Text_Bytes)
+                f.close()
+            elif message.Text_Body:
+                with open(filename + ".txt", "w") as f:
+                    f.write(message.Text_Body)
+                f.close()
+            else:
+                log.warn("Error writing html derivative, no body present for " + str(message.Mailbag_Message_ID))

--- a/mailbag/derivatives/html.py
+++ b/mailbag/derivatives/html.py
@@ -1,5 +1,6 @@
 # Makes html derivatives just containing message bodies
 import os
+import mailbag.helper as helper
 from structlog import get_logger
 
 log = get_logger()
@@ -25,24 +26,26 @@ class HtmlDerivative(Derivative):
             out_dir = os.path.join(mailbag_dir, self.derivative_format, message.Message_Path)
         filename = os.path.join(out_dir, str(message.Mailbag_Message_ID))
 
-        log.debug("Writing html derivative to " + filename)
+        norm_dir = helper.normalizePath(out_dir)
+        norm_filename = helper.normalizePath(filename)
+        log.debug("Writing html derivative to " + norm_filename)
         if not args.dry_run:
-            if not os.path.isdir(out_dir):
-                os.makedirs(out_dir)
+            if not os.path.isdir(norm_dir):
+                os.makedirs(norm_dir)
             if message.HTML_Bytes:
-                with open(filename + ".html", "wb") as f:
+                with open(norm_filename + ".html", "wb") as f:
                     f.write(message.HTML_Bytes)
                 f.close()
             elif message.HTML_Body:
-                with open(filename + ".html", "w") as f:
+                with open(norm_filename + ".html", "w") as f:
                     f.write(message.HTML_Body)
                 f.close()
             elif message.Text_Bytes:
-                with open(filename + ".txt", "wb") as f:
+                with open(norm_filename + ".txt", "wb") as f:
                     f.write(message.Text_Bytes)
                 f.close()
             elif message.Text_Body:
-                with open(filename + ".txt", "w") as f:
+                with open(norm_filename + ".txt", "w") as f:
                     f.write(message.Text_Body)
                 f.close()
             else:

--- a/mailbag/derivatives/pdf.py
+++ b/mailbag/derivatives/pdf.py
@@ -55,7 +55,10 @@ class ExampleDerivative(Derivative):
                 #fallback to just prepending the table
                 html_content = table + body
 
-            pdf_path = os.path.join(mailbag_dir, "pdf")
+            if message.Message_Path is None:
+                pdf_path = os.path.join(mailbag_dir, self.derivative_format)
+            else:
+                pdf_path = os.path.join(mailbag_dir, self.derivative_format, message.Message_Path)
             html_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".html")
             pdf_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".pdf")
             log.debug("Writing HTML to " + str(html_name) + " and converting to " + str(pdf_name))

--- a/mailbag/derivatives/pdf.py
+++ b/mailbag/derivatives/pdf.py
@@ -20,6 +20,7 @@ if not skip_registry:
 
     class ExampleDerivative(Derivative):
         derivative_name = 'pdf'
+        derivative_format = 'pdf'
         wkhtmltopdf = 'wkhtmltopdf.exe'
         
         def __init__(self, email_account, **kwargs):

--- a/mailbag/derivatives/pdf.py
+++ b/mailbag/derivatives/pdf.py
@@ -47,7 +47,7 @@ if not skip_registry:
                 headerFields=[]
                 #Getting all the required attributes of message except error and body
                 for attribute in message:
-                    if(attribute[0] not in ("Error","Text_Body","HTML_Body","Message","Headers") ):
+                    if(attribute[0] not in ("Error","Text_Body", "Text_Bytes", "HTML_Body", "HTML_Bytes", "Message","Headers", "AttachmentFiles")):
                         headerFields.append(attribute[0])
                 #Getting the values of the attrbutes and appending to HTML string
                 for headerField in headerFields:

--- a/mailbag/derivatives/pdf.py
+++ b/mailbag/derivatives/pdf.py
@@ -18,7 +18,7 @@ class ExampleDerivative(Derivative):
     def do_task_per_account(self):
         print(self.account.account_data())
 
-    def do_task_per_message(self, message, args):
+    def do_task_per_message(self, message, args, mailbag_dir):
         
         
         #check to see which body to use
@@ -55,7 +55,7 @@ class ExampleDerivative(Derivative):
                 #fallback to just prepending the table
                 html_content = table + body
 
-            pdf_path = os.path.join(args.directory, args.mailbag_name, "pdf")
+            pdf_path = os.path.join(mailbag_dir, "pdf")
             html_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".html")
             pdf_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".pdf")
             log.debug("Writing HTML to " + str(html_name) + " and converting to " + str(pdf_name))

--- a/mailbag/derivatives/pdf.py
+++ b/mailbag/derivatives/pdf.py
@@ -3,6 +3,7 @@ import subprocess
 import distutils.spawn
 from mailbag.derivative import Derivative
 from structlog import get_logger
+import mailbag.helper as helper
 
 # only create format if pypff is successfully importable -
 # pst is not supported otherwise
@@ -66,9 +67,9 @@ if not skip_registry:
                     html_content = table + body
 
                 if message.Message_Path is None:
-                    pdf_path = os.path.join(mailbag_dir, self.derivative_format)
+                    pdf_path = helper.normalizePath(os.path.join(mailbag_dir, self.derivative_format))
                 else:
-                    pdf_path = os.path.join(mailbag_dir, self.derivative_format, message.Message_Path)
+                    pdf_path = helper.normalizePath(os.path.join(mailbag_dir, self.derivative_format, message.Message_Path))
                 html_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".html")
                 pdf_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".pdf")
                 log.debug("Writing HTML to " + str(html_name) + " and converting to " + str(pdf_name))

--- a/mailbag/derivatives/pdf.py
+++ b/mailbag/derivatives/pdf.py
@@ -76,7 +76,7 @@ if not skip_registry:
                 log.debug("Writing HTML to " + str(html_name) + " and converting to " + str(pdf_name))
                 if not args.dry_run:
                     if not os.path.isdir(pdf_path):
-                            os.mkdir(pdf_path)
+                        os.makedirs(pdf_path)
                     write_html = open(html_name, 'w')
                     write_html.write(html_content)
                     write_html.close()

--- a/mailbag/derivatives/pdf.py
+++ b/mailbag/derivatives/pdf.py
@@ -4,89 +4,90 @@ import distutils.spawn
 from mailbag.derivative import Derivative
 from structlog import get_logger
 
+# only create format if pypff is successfully importable -
+# pst is not supported otherwise
+skip_registry = False
+try:
+    if not distutils.spawn.find_executable('wkhtmltopdf.exe'):
+        skip_registry = True
+except:
+    skip_registry = True
+
 log = get_logger()
-class ExampleDerivative(Derivative):
-    derivative_name = 'pdf'
-    wkhtmltopdf = 'wkhtmltopdf.exe'
-    
-    def __init__(self, email_account, **kwargs):
-        print("Setup account")
-        if not distutils.spawn.find_executable(self.wkhtmltopdf):
-            raise OSError("wkhtmltopdf.exe not found. To create PDF derivatives, ensure that wkhtmltopdf is installed and in PATH.")
-        super()
 
-    def do_task_per_account(self):
-        print(self.account.account_data())
+if not skip_registry:
 
-    def do_task_per_message(self, message, args, mailbag_dir):
+    class ExampleDerivative(Derivative):
+        derivative_name = 'pdf'
+        wkhtmltopdf = 'wkhtmltopdf.exe'
         
-        
-        #check to see which body to use
-        body = False
-        if message.HTML_Body:
-            body = message.HTML_Body
-        elif message.Text_Body:
-            body = message.Text_Body
-        else:
-            log.debug("Unable to create PDF, no body found for " + str(message.Mailbag_Message_ID))
+        def __init__(self, email_account, **kwargs):
+            log.debug("Setup account")
+            super()
 
-        if body:
-            table="<table>"
-            headerFields=[]
-            #Getting all the required attributes of message except error and body
-            for attribute in message:
-                if(attribute[0] not in ("Error","Text_Body","HTML_Body","Message","Headers") ):
-                    headerFields.append(attribute[0])
-            #Getting the values of the attrbutes and appending to HTML string
-            for headerField in headerFields:
-                if not getattr(message,headerField) is None:
-                    table += "<tr>"
-                    table += "<td>"+str(headerField)+"</td>"
-                    table += "<td>"+str(getattr(message,headerField))+"</td>"
-                    table += "</tr>"
-            table += "</table>"
+        def do_task_per_account(self):
+            print(self.account.account_data())
 
-            #add headers table to html
-            if message.HTML_Body and "<body" in body.lower():
-                body_position = body.lower().index("<body")
-                table_position = body_position + body[body_position:].index(">") + 1
-                html_content = body[:table_position] + table + body[table_position:]
+        def do_task_per_message(self, message, args, mailbag_dir):
+            
+            
+            #check to see which body to use
+            body = False
+            if message.HTML_Body:
+                body = message.HTML_Body
+            elif message.Text_Body:
+                body = message.Text_Body
             else:
-                #fallback to just prepending the table
-                html_content = table + body
+                log.debug("Unable to create PDF, no body found for " + str(message.Mailbag_Message_ID))
 
-            if message.Message_Path is None:
-                pdf_path = os.path.join(mailbag_dir, self.derivative_format)
-            else:
-                pdf_path = os.path.join(mailbag_dir, self.derivative_format, message.Message_Path)
-            html_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".html")
-            pdf_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".pdf")
-            log.debug("Writing HTML to " + str(html_name) + " and converting to " + str(pdf_name))
-            if not args.dry_run:
-                if not os.path.isdir(pdf_path):
-                        os.mkdir(pdf_path)
-                write_html = open(html_name, 'w')
-                write_html.write(html_content)
-                write_html.close()
-                p = subprocess.Popen([self.wkhtmltopdf, html_name, pdf_name],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-                stdout, stderr = p.communicate()
-                if p.returncode == 0:
-                    log.debug("Successfully created " + str(message.Mailbag_Message_ID )+".pdf")
+            if body:
+                table="<table>"
+                headerFields=[]
+                #Getting all the required attributes of message except error and body
+                for attribute in message:
+                    if(attribute[0] not in ("Error","Text_Body","HTML_Body","Message","Headers") ):
+                        headerFields.append(attribute[0])
+                #Getting the values of the attrbutes and appending to HTML string
+                for headerField in headerFields:
+                    if not getattr(message,headerField) is None:
+                        table += "<tr>"
+                        table += "<td>"+str(headerField)+"</td>"
+                        table += "<td>"+str(getattr(message,headerField))+"</td>"
+                        table += "</tr>"
+                table += "</table>"
+
+                #add headers table to html
+                if message.HTML_Body and "<body" in body.lower():
+                    body_position = body.lower().index("<body")
+                    table_position = body_position + body[body_position:].index(">") + 1
+                    html_content = body[:table_position] + table + body[table_position:]
                 else:
-                    if stdout:
-                        log.error("Error creating " + str(message.Mailbag_Message_ID )+".pdf: " + str(stdout))
-                    if stderr:
-                        log.error("Error creating " + str(message.Mailbag_Message_ID )+".pdf: " + str(stderr))
-                    #comment out for now since catches even very minor issues
-                    #raise TypeError(stderr)
-                # delete the HTML file
-                os.remove(html_name)
+                    #fallback to just prepending the table
+                    html_content = table + body
 
-
-
-
-
-
-
-
-
+                if message.Message_Path is None:
+                    pdf_path = os.path.join(mailbag_dir, self.derivative_format)
+                else:
+                    pdf_path = os.path.join(mailbag_dir, self.derivative_format, message.Message_Path)
+                html_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".html")
+                pdf_name = os.path.join(pdf_path, str(message.Mailbag_Message_ID )+".pdf")
+                log.debug("Writing HTML to " + str(html_name) + " and converting to " + str(pdf_name))
+                if not args.dry_run:
+                    if not os.path.isdir(pdf_path):
+                            os.mkdir(pdf_path)
+                    write_html = open(html_name, 'w')
+                    write_html.write(html_content)
+                    write_html.close()
+                    p = subprocess.Popen([self.wkhtmltopdf, html_name, pdf_name],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+                    stdout, stderr = p.communicate()
+                    if p.returncode == 0:
+                        log.debug("Successfully created " + str(message.Mailbag_Message_ID )+".pdf")
+                    else:
+                        if stdout:
+                            log.error("Error creating " + str(message.Mailbag_Message_ID )+".pdf: " + str(stdout))
+                        if stderr:
+                            log.error("Error creating " + str(message.Mailbag_Message_ID )+".pdf: " + str(stderr))
+                        #comment out for now since catches even very minor issues
+                        #raise TypeError(stderr)
+                    # delete the HTML file
+                    os.remove(html_name)

--- a/mailbag/derivatives/txt.py
+++ b/mailbag/derivatives/txt.py
@@ -19,10 +19,10 @@ class TxtDerivative(Derivative):
 
     def do_task_per_message(self, message, args, mailbag_dir):
 
-        if message.Email_Folder is None:
+        if message.Message_Path is None:
             out_dir = os.path.join(mailbag_dir, self.derivative_format)
         else:
-            out_dir = os.path.join(mailbag_dir, self.derivative_format, message.Email_Folder)
+            out_dir = os.path.join(mailbag_dir, self.derivative_format, message.Message_Path)
         filename = os.path.join(out_dir, str(message.Mailbag_Message_ID) + "." + self.derivative_format)
 
         if message.Text_Body is None:
@@ -32,6 +32,11 @@ class TxtDerivative(Derivative):
             if not args.dry_run:
                 if not os.path.isdir(out_dir):
                     os.makedirs(out_dir)
-                with open(filename, "w") as f:
-                    f.write(message.Text_Body)
+                if message.Text_Bytes:
+                    with open(filename, "wb") as f:
+                        f.write(message.Text_Bytes)
+                    f.close()
+                elif message.Text_Body:
+                    with open(filename, "w") as f:
+                        f.write(message.Text_Body)
                     f.close()

--- a/mailbag/derivatives/txt.py
+++ b/mailbag/derivatives/txt.py
@@ -1,5 +1,6 @@
 # Makes txt file derivatives just containing message bodies
 import os
+import mailbag.helper as helper
 from structlog import get_logger
 
 log = get_logger()
@@ -25,18 +26,20 @@ class TxtDerivative(Derivative):
             out_dir = os.path.join(mailbag_dir, self.derivative_format, message.Message_Path)
         filename = os.path.join(out_dir, str(message.Mailbag_Message_ID) + "." + self.derivative_format)
 
+        norm_dir = helper.normalizePath(out_dir)
+        norm_filename = helper.normalizePath(filename)
         if message.Text_Body is None:
             log.warn("Error writing txt derivative for " + str(message.Mailbag_Message_ID))
         else:
-            log.debug("Writing txt derivative to " + filename)
+            log.debug("Writing txt derivative to " + norm_filename)
             if not args.dry_run:
-                if not os.path.isdir(out_dir):
-                    os.makedirs(out_dir)
+                if not os.path.isdir(norm_dir):
+                    os.makedirs(norm_dir)
                 if message.Text_Bytes:
-                    with open(filename, "wb") as f:
+                    with open(norm_filename, "wb") as f:
                         f.write(message.Text_Bytes)
                     f.close()
                 elif message.Text_Body:
-                    with open(filename, "w") as f:
+                    with open(norm_filename, "w") as f:
                         f.write(message.Text_Body)
                     f.close()

--- a/mailbag/formats/eml.py
+++ b/mailbag/formats/eml.py
@@ -49,23 +49,29 @@ class EML(EmailAccount):
 
                     try:
                         html_body = None
+                        html_bytes = None
                         text_body = None
+                        text_bytes = None
                         if msg.is_multipart():
                             for part in msg.walk():
                                 content_type = part.get_content_type()
                                 content_disposition = part.get_content_disposition()
                                 #character_set = part.get_charsets()
                                 if content_type == "text/html" and content_disposition != "attachment":
-                                    html_body = part.get_payload(decode=True)
+                                    html_bytes = part.get_payload(decode=True)
+                                    html_body = part.get_payload()
                                 if content_type == "text/plain" and content_disposition != "attachment":
-                                    text_body = part.get_payload(decode=True)
+                                    text_bytes = part.get_payload(decode=True)
+                                    text_body = part.get_payload()
                         else:
                             content_type = msg.get_content_type()
                             content_disposition = msg.get_content_disposition()
                             if content_type == "text/html" and content_disposition != "attachment":
-                                html_body = part.get_payload(decode=True)
+                                html_bytes= part.get_payload(decode=True)
+                                html_body = part.get_payload()
                             if content_type == "text/plain" and content_disposition != "attachment":
-                                text_body = part.get_payload(decode=True)
+                                text_bytes = part.get_payload(decode=True)
+                                text_body = part.get_payload()
                     except Exception as e:
                         log.error(e)
                         error.append("Error parsing message body.")
@@ -94,8 +100,10 @@ class EML(EmailAccount):
                             Subject=msg["subject"],
                             Content_Type=msg.get_content_type(),
                             Headers=msg,
-                            Text_Bytes=text_body,
-                            HTML_Bytes=html_body,
+                            HTML_Bytes=html_bytes,
+                            HTML_Body=html_body,
+                            Text_Bytes=text_bytes,
+                            Text_Body=text_body,
                             Message=msg,
                             AttachmentNum=len(attachmentNames) if attachmentNames else 0,
                             AttachmentNames=attachmentNames,

--- a/mailbag/formats/eml.py
+++ b/mailbag/formats/eml.py
@@ -39,8 +39,8 @@ class EML(EmailAccount):
 
             subFolder = helper.emailFolder(self.file, filePath)
 
+            error = []
             try:
-                error = []
 
                 attachmentNames = []
                 attachments = []
@@ -112,7 +112,7 @@ class EML(EmailAccount):
 
             except (email.errors.MessageParseError, Exception) as e:
                 message = Email(
-                    Error=['Error parsing message.']
+                    Error=error.append('Error parsing message.')
                 )
 
             # Move EML to new mailbag directory structure

--- a/mailbag/formats/eml.py
+++ b/mailbag/formats/eml.py
@@ -24,8 +24,8 @@ class EML(EmailAccount):
         account_data = {}
 
         self.file = target_account
-        # self.dry_run = dry_run
-        # self.mailbag_name = mailbag_name
+        self.dry_run = args.dry_run
+        self.mailbag_name = args.mailbag_name
         log.info("Reading : ", File=self.file)
 
     def account_data(self):
@@ -37,54 +37,76 @@ class EML(EmailAccount):
 
         for filePath in files:
 
+            subFolder = helper.emailFolder(self.file, filePath)
+
             try:
-                error = False
+                error = []
 
                 attachmentNames = []
                 attachments = []
-                with open(filePath, 'r') as f:
-                    msg = email.message_from_file(f, policy=policy.default)
-                    body = msg.get_body(preferencelist=('related', 'html', 'plain')).__str__()
+                with open(filePath, 'rb') as f:
+                    msg = email.message_from_binary_file(f, policy=policy.default)
 
-                    # Extract Attachments                
-                    for attachment in msg.iter_attachments():
-                        attachmentName, attachment = helper.saveAttachments(attachment)
-                        if attachmentName:
-                            attachmentNames.append(attachmentName)
+                    try:
+                        html_body = None
+                        text_body = None
+                        if msg.is_multipart():
+                            for part in msg.walk():
+                                content_type = part.get_content_type()
+                                content_disposition = part.get_content_disposition()
+                                #character_set = part.get_charsets()
+                                if content_type == "text/html" and content_disposition != "attachment":
+                                    html_body = part.get_payload(decode=True)
+                                if content_type == "text/plain" and content_disposition != "attachment":
+                                    text_body = part.get_payload(decode=True)
                         else:
-                            attachmentNames.append(str(len(attachmentNames)))
-                        attachments.append(attachment)
-                    
-                    if msg.is_multipart():
-                            
-                        for part in msg.walk():
-                            if part.get_content_type() == "text/html":
-                                html_body = part.get_payload()
-                            elif part.get_content_type() == "text/plain":
-                                text_body = part.get_payload()
-                                log.debug("Content-type "+part.get_content_maintype())
+                            content_type = msg.get_content_type()
+                            content_disposition = msg.get_content_disposition()
+                            if content_type == "text/html" and content_disposition != "attachment":
+                                html_body = part.get_payload(decode=True)
+                            if content_type == "text/plain" and content_disposition != "attachment":
+                                text_body = part.get_payload(decode=True)
+                    except Exception as e:
+                        log.error(e)
+                        error.append("Error parsing message body.")
+
+                    try:
+                        # Extract Attachments                
+                        for attachment in msg.iter_attachments():
+                            attachmentName, attachment = helper.saveAttachments(attachment)
+                            if attachmentName:
+                                attachmentNames.append(attachmentName)
+                            else:
+                                attachmentNames.append(str(len(attachmentNames)))
+                            attachments.append(attachment)
+                    except Exception as e:
+                        log.error(e)
+                        error.append("Error parsing attachments.")
                                     
-                message = Email(
-                        # Email_Folder=helper.emailFolder(self.dry_run, self.mailbag_name, self.format_name, self.file, filePath),
-                        Message_ID=msg["Message-id"],
-                        Original_Filename=str(os.path.basename(filePath)),
-                        Date=msg["date"],
-                        From=msg["from"],
-                        To=msg["to"],
-                        Subject=msg["subject"],
-                        Content_Type=msg["content-type"],
-                        Body=body,
-                        Text_Body=text_body,
-                        HTML_Body=html_body,
-                        AttachmentNum=len(attachmentNames) if attachmentNames else 0,
-                        AttachmentNames=attachmentNames,
-                        AttachmentFiles=attachments,
-                        Error=str(error)
-                    )
+                    message = Email(
+                            Error=error,
+                            Message_ID=msg["message-id"].strip(),
+                            Message_Path=subFolder,
+                            Original_Filename=str(os.path.basename(filePath)),
+                            Date=msg["date"],
+                            From=msg["from"],
+                            To=msg["to"],
+                            Subject=msg["subject"],
+                            Content_Type=msg.get_content_type(),
+                            Headers=msg,
+                            Text_Bytes=text_body,
+                            HTML_Bytes=html_body,
+                            Message=msg,
+                            AttachmentNum=len(attachmentNames) if attachmentNames else 0,
+                            AttachmentNames=attachmentNames,
+                            AttachmentFiles=attachments
+                        )
 
             except (email.errors.MessageParseError, Exception) as e:
                 message = Email(
-                    Error='True'
+                    Error=['Error parsing message.']
                 )
 
+            # Move EML to new mailbag directory structure
+            new_path = helper.moveWithDirectoryStructure(self.dry_run,self.file,self.mailbag_name,self.format_name,subFolder,filePath)
             yield message

--- a/mailbag/formats/mbox.py
+++ b/mailbag/formats/mbox.py
@@ -38,7 +38,7 @@ class Mbox(EmailAccount):
             parent_dir = self.file
         file_list = glob.glob(files, recursive=True)
         for filePath in file_list:
-            subFolder = helper.emailFolder(parent_dir, filePath, True)
+            subFolder = helper.emailFolder(parent_dir, filePath)
 
             data = mailbox.mbox(filePath)
             for mail in data.itervalues():

--- a/mailbag/formats/mbox.py
+++ b/mailbag/formats/mbox.py
@@ -30,9 +30,15 @@ class Mbox(EmailAccount):
 
     def messages(self):
         
-        files = glob.glob(os.path.join(self.file, "**", "*.mbox"), recursive=True)
-        for filePath in files:
-            subFolder = helper.emailFolder(self.file,filePath)
+        if os.path.isfile(self.file):
+            files = self.file
+            parent_dir = os.path.dirname(self.file)
+        else:
+            files = os.path.join(self.file, "**", "*.mbox")
+            parent_dir = self.file
+        file_list = glob.glob(files, recursive=True)
+        for filePath in file_list:
+            subFolder = helper.emailFolder(parent_dir, filePath)
 
             data = mailbox.mbox(filePath)
             for mail in data.itervalues():
@@ -91,4 +97,4 @@ class Mbox(EmailAccount):
             # Make sure the MBOX file is closed
             data.close()
             # Move MBOX to new mailbag directory structure
-            new_path = helper.moveWithDirectoryStructure(self.dry_run,self.file,self.mailbag_name,self.format_name,subFolder,filePath)
+            new_path = helper.moveWithDirectoryStructure(self.dry_run,parent_dir,self.mailbag_name,self.format_name,subFolder,filePath)

--- a/mailbag/formats/mbox.py
+++ b/mailbag/formats/mbox.py
@@ -42,8 +42,8 @@ class Mbox(EmailAccount):
 
             data = mailbox.mbox(filePath)
             for mail in data.itervalues():
+                error = []
                 try:
-                    error = []
                     mailObject = email.message_from_bytes(mail.as_bytes(),policy=email.policy.default)
 
                     # Try to parse content
@@ -114,7 +114,7 @@ class Mbox(EmailAccount):
                 except (email.errors.MessageParseError, Exception) as e:
                     log.error(e)
                     message = Email(
-                        Error=['Error parsing message.']
+                        Error=error.append('Error parsing message.')
                     )
                 yield message
 

--- a/mailbag/formats/mbox.py
+++ b/mailbag/formats/mbox.py
@@ -70,6 +70,7 @@ class Mbox(EmailAccount):
                     message = Email(
                         Message_ID=mail['Message-ID'],
                         Email_Folder=subFolder,
+                        Original_Filename=str(os.path.basename(filePath)),
                         Date=mail['Date'],
                         From=mail['From'],
                         To=mail['To'],

--- a/mailbag/formats/mbox.py
+++ b/mailbag/formats/mbox.py
@@ -49,23 +49,29 @@ class Mbox(EmailAccount):
                     # Try to parse content
                     try:
                         html_body = None
+                        html_bytes = None
                         text_body = None
+                        text_bytes = None
                         if mailObject.is_multipart():
                             for part in mailObject.walk():
                                 content_type = part.get_content_type()
                                 content_disposition = part.get_content_disposition()
                                 #character_set = part.get_charsets()
                                 if content_type == "text/html" and content_disposition != "attachment":
-                                    html_body = part.get_payload(decode=True)
+                                    html_bytes = part.get_payload(decode=True)
+                                    html_body = part.get_payload()
                                 if content_type == "text/plain" and content_disposition != "attachment":
-                                    text_body = part.get_payload(decode=True)
+                                    text_bytes = part.get_payload(decode=True)
+                                    text_body = part.get_payload()
                         else:
                             content_type = mailObject.get_content_type()
                             content_disposition = mailObject.get_content_disposition()
                             if content_type == "text/html" and content_disposition != "attachment":
-                                html_body = part.get_payload(decode=True)
+                                html_bytes = part.get_payload(decode=True)
+                                html_body = part.get_payload()
                             if content_type == "text/plain" and content_disposition != "attachment":
-                                text_body = part.get_payload(decode=True)
+                                text_bytes = part.get_payload(decode=True)
+                                text_body = part.get_payload()
                     except Exception as e:
                         log.error(e)
                         error.append("Error parsing message body.")
@@ -96,8 +102,10 @@ class Mbox(EmailAccount):
                         Subject=mail['Subject'],
                         Content_Type=mailObject.get_content_type(),
                         Headers=mail,
-                        Text_Bytes=text_body,
-                        HTML_Bytes=html_body,
+                        HTML_Bytes=html_bytes,
+                        HTML_Body=html_body,
+                        Text_Bytes=text_bytes,
+                        Text_Body=text_body,
                         Message=mailObject,
                         AttachmentNum=len(attachmentNames) if attachmentNames else 0,
                         AttachmentNames=attachmentNames,

--- a/mailbag/formats/msg.py
+++ b/mailbag/formats/msg.py
@@ -36,10 +36,10 @@ class MSG(EmailAccount):
             
             subFolder = helper.emailFolder(self.file, filePath)
             
+            error = []
             try:
                 mail = extract_msg.openMsg(filePath)
                 html_body = None
-                error = []
                 
                 # Extract HTML from RTF if no HTML body
                 try:
@@ -97,7 +97,7 @@ class MSG(EmailAccount):
             
             except (email.errors.MessageParseError, Exception) as e:
                 message = Email(
-                    Error=['Error parsing message.']
+                    Error=error.append('Error parsing message.')
                 )
  
             # Move MSG to new mailbag directory structure

--- a/mailbag/formats/msg.py
+++ b/mailbag/formats/msg.py
@@ -68,7 +68,9 @@ class MSG(EmailAccount):
                     attachments.append(attachment.data)
                 
                 message = Email(
+                    Message_ID = mail.messageId.strip(),
                     Email_Folder=subFolder,
+                    Original_Filename=str(os.path.basename(filePath)),
                     Date=mail.date,
                     From=mail.sender,
                     To=mail.to,
@@ -95,6 +97,6 @@ class MSG(EmailAccount):
                     Error='True'
                 )
  
-            # Move MBOX to new mailbag directory structure
+            # Move MSG to new mailbag directory structure
             new_path = helper.moveWithDirectoryStructure(self.dry_run,self.file,self.mailbag_name,self.format_name,subFolder,filePath)
             yield message

--- a/mailbag/formats/msg.py
+++ b/mailbag/formats/msg.py
@@ -38,38 +38,41 @@ class MSG(EmailAccount):
             
             try:
                 mail = extract_msg.openMsg(filePath)
-                
                 html_body = None
-                error = False
+                error = []
                 
                 # Extract HTML from RTF if no HTML body
                 try:
                     if mail.htmlBody:
                         html_body = mail.htmlBody
-                    else:
+                    elif mail.rtfBody:
                         rtf_obj = DeEncapsulator(mail.rtfBody)
                         rtf_obj.deencapsulate()
                         if rtf_obj.content_type == 'html':
                             html_body = rtf_obj.html
                 except Exception as e:
                     log.error(e)
-                    error = True
+                    error.append("Error parsing message body.")
 
-                attachmentNames = []
-                attachments = []
-                                
-                for attachment in mail.attachments:
-                    if attachment.longFilename:
-                        attachmentNames.append(attachment.longFilename)
-                    elif attachment.shortFilename:
-                        attachmentNames.append(attachment.shortFilename)
-                    else:
-                        attachmentNames.append(str(len(attachmentNames)))
-                    attachments.append(attachment.data)
-                
+                try:
+                    attachmentNames = []
+                    attachments = []             
+                    for attachment in mail.attachments:
+                        if attachment.longFilename:
+                            attachmentNames.append(attachment.longFilename)
+                        elif attachment.shortFilename:
+                            attachmentNames.append(attachment.shortFilename)
+                        else:
+                            attachmentNames.append(str(len(attachmentNames)))
+                        attachments.append(attachment.data)
+                except Exception as e:
+                    log.error(e)
+                    error.append("Error parsing attachments.")
+
                 message = Email(
+                    Error= error,
                     Message_ID = mail.messageId.strip(),
-                    Email_Folder=subFolder,
+                    Message_Path=subFolder,
                     Original_Filename=str(os.path.basename(filePath)),
                     Date=mail.date,
                     From=mail.sender,
@@ -77,6 +80,7 @@ class MSG(EmailAccount):
                     Cc=mail.cc,
                     Bcc=mail.bcc ,
                     Subject=mail.subject,
+                    Content_Type=mail.header.get_content_type(),
                     # mail.header appears to be a headers object oddly enough
                     Headers=mail.header,
                     Body=html_body,
@@ -86,15 +90,14 @@ class MSG(EmailAccount):
                     Message=None,
                     AttachmentNum=len(attachmentNames),
                     AttachmentNames=attachmentNames,
-                    AttachmentFiles=attachments,
-                    Error= str(error)
+                    AttachmentFiles=attachments
                 )
                 # Make sure the MSG file is closed
                 mail.close()
             
             except (email.errors.MessageParseError, Exception) as e:
                 message = Email(
-                    Error='True'
+                    Error=['Error parsing message.']
                 )
  
             # Move MSG to new mailbag directory structure

--- a/mailbag/formats/pst.py
+++ b/mailbag/formats/pst.py
@@ -63,7 +63,7 @@ if not skip_registry:
 
                         message = Email(
                             Message_ID=headers['Message-ID'],
-                            Email_Folder=os.path.join(*path),
+                            Message_Path=os.path.join(*path),
                             Original_Filename=path[-1],
                             Date=headers["Date"],
                             From=headers["From"],

--- a/mailbag/formats/pst.py
+++ b/mailbag/formats/pst.py
@@ -64,6 +64,7 @@ if not skip_registry:
                         message = Email(
                             Message_ID=headers['Message-ID'],
                             Email_Folder=os.path.join(*path),
+                            Original_Filename=path[-1],
                             Date=headers["Date"],
                             From=headers["From"],
                             To=headers["To"],

--- a/mailbag/formats/pst.py
+++ b/mailbag/formats/pst.py
@@ -44,8 +44,8 @@ if not skip_registry:
                 path.append(folder.name)
                 for index in range(folder.number_of_sub_messages):
                     
+                    error = []
                     try:
-                        error = []
                         messageObj = folder.get_sub_message(index)
 
                         try:
@@ -115,7 +115,7 @@ if not skip_registry:
                     except (Exception) as e:
                         log.error(e)
                         message = Email(
-                            Error=['Error parsing message.']
+                            Error=error.append('Error parsing message.')
                         )
                 
                     # log.debug(message.to_struct())

--- a/mailbag/helper.py
+++ b/mailbag/helper.py
@@ -1,3 +1,4 @@
+import urllib.parse
 from pathlib import Path
 import os, shutil, glob
 from structlog import get_logger
@@ -79,3 +80,23 @@ def moveWithDirectoryStructure(dry_run, mainPath, mailbag_name, input, emailFold
 def saveAttachments(part):
     return (part.get_filename(),part.get_payload(decode=True))
     
+
+def normalizePath(path):
+    # this is not sufficent yet
+    if os.name == "nt":
+        specials = ["<", ">", ":", "\"", "/", "|", "?", "*"]
+        special_names = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", \
+        "COM", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"]
+        new_path = []
+        for name in os.path.normpath(path).split(os.sep):
+            illegal = False
+            for char in specials:
+                if char in name:
+                    illegal = True
+            if illegal:
+                new_path.append(urllib.parse.quote_plus(name))
+            else:
+                new_path.append(name)
+        return os.path.join(*new_path)
+    else:
+        return path

--- a/mailbag/helper.py
+++ b/mailbag/helper.py
@@ -66,7 +66,7 @@ def moveWithDirectoryStructure(dry_run, mainPath, mailbag_name, input, emailFold
             p = fullFilePath.parents[0]
             while p != p.root and p != fullPath:
                 if not os.listdir(p):
-                    log.debug('Cleaning: ' + p)
+                    log.debug('Cleaning: ' + str(p))
                     os.rmdir(p)
                     # dirty hack since rmdir is not synchronous on Windows
                     if os.name == "nt":

--- a/mailbag/models.py
+++ b/mailbag/models.py
@@ -3,8 +3,10 @@ from email.message import Message
 
 class Email(models.Base):
     """EmailModel - model class for email formats"""
+    Error = fields.ListField(str)
+    Mailbag_Message_ID=fields.IntField()
     Message_ID = fields.StringField()
-    Email_Folder = fields.StringField()
+    Message_Path = fields.StringField()
     Original_Filename = fields.StringField()
     Date = fields.StringField()
     From = fields.StringField()
@@ -14,12 +16,11 @@ class Email(models.Base):
     Subject = fields.StringField()
     Content_Type = fields.StringField()
     Headers = fields.EmbeddedField(Message)
-    Body = fields.StringField()
     HTML_Body = fields.StringField()
+    HTML_Bytes = fields.EmbeddedField(bytes)
     Text_Body = fields.StringField()
+    Text_Bytes = fields.EmbeddedField(bytes)
     Message = fields.EmbeddedField(Message)
     AttachmentNum = fields.IntField()
     AttachmentNames = fields.ListField(str)
-    AttachmentFiles = fields.ListField(bytes)
-    Error = fields.StringField()
-    Mailbag_Message_ID=fields.IntField()
+    AttachmentFiles = fields.ListField(bytes)    


### PR DESCRIPTION
 ## Type of Contribution

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [X] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Addresses a number of format parser issues. `mailbagit` now handles both directory and individual file input for PSTs and MBOXs. Parsers now return both binary and string bodies to the model (except MSG only provides string) for improved fidelity for derivatives. Model fields now more closely follow the specification (Email_Folder is now Message_Path). Also provides more structured error messages back to the model using a list. Derivatives also minimally normalize file paths from PSTs with special characters, though this needs further improvement.

PDF derivatives still only use string bodies for now, which needs to be addressed.

## Link to issue?

#107 #108 #94 #93 #90 #86

- [X] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to the develop branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [X] All tests pass

#### How has this been tested?
**Operating System:** Win10
**Python Version:** 3.8 and 3.9

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbag/blob/main/LICENSE).
