### PR TITLE
fixes bug where pst parser looked for mbox files

### DIFF
--- a/mailbag/formats/pst.py
+++ b/mailbag/formats/pst.py
@@ -135,7 +135,7 @@ if not skip_registry:
                 files = self.file
                 parent_dir = os.path.dirname(self.file)
             else:
-                files = os.path.join(self.file, "**", "*.mbox")
+                files = os.path.join(self.file, "**", "*.pst")
                 parent_dir = self.file
             file_list = glob.glob(files, recursive=True)
 


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Adds

## Link to issue?

#23 

- [x] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [ ] All tests pass

#### How has this been tested?
**Operating System:* Win10
**Python Version:** 3.9

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbag/blob/main/LICENSE).
