### PR TITLE
uses built-in method to extract encoding integer instead of struct

### DIFF
--- a/mailbag/formats/pst.py
+++ b/mailbag/formats/pst.py
@@ -2,7 +2,6 @@ import os, glob
 import mailbox
 from pathlib import Path
 import chardet
-import struct
 from extract_msg.constants import CODE_PAGES
 from structlog import get_logger
 from email import parser
@@ -84,12 +83,12 @@ if not skip_registry:
                                 for entry in record_set.entries:
                                     if entry.entry_type == LIBPFF_ENTRY_TYPE_MESSAGE_BODY_CODEPAGE:
                                         if entry.data:
-                                            value = struct.unpack("i", entry.data)[0]
+                                            value = entry.get_data_as_integer()
                                             # Use the extract_msg code page in constants.py
                                             encodings["PidTagInternetCodepage"] = CODE_PAGES[value]
                                     if entry.entry_type == LIBPFF_ENTRY_TYPE_MESSAGE_CODEPAGE:
                                         if entry.data:
-                                            value = struct.unpack("i", entry.data)[0]
+                                            value = entry.get_data_as_integer()
                                             # Use the extract_msg code page in constants.py
                                             encodings["PidTagMessageCodepage"] = CODE_PAGES[value]
 


### PR DESCRIPTION
 ## Type of Contribution

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [x] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

I didn't know there was a built-in method to extract the encoding lookup integer with libpff. This uses that method instead of relying on `struct.unpack`.

## Link to issue?

n/a

- [ ] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to the develop branch. Don't PR to main!
- [x] This contribution has sufficient documentation
- [x] Tests for the changes have been added
- [x] All tests pass

#### How has this been tested?
**Operating System:** Win10
**Python Version:** 3.7.3

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbag/blob/main/LICENSE).
