### PR TITLE
allows google-chrome as a command for non-windows systems

### DIFF
--- a/mailbag/derivatives/pdf-chrome.py
+++ b/mailbag/derivatives/pdf-chrome.py
@@ -7,16 +7,12 @@ import mailbag.helper as helper
 
 
 skip_registry = False
+
 try:
-    if distutils.spawn.find_executable("google-chrome"):
-        chrome = "google-chrome"
-    elif distutils.spawn.find_executable("chrome.exe"):
-        chrome = "chrome.exe"
-    elif distutils.spawn.find_executable("chrome"):
-        chrome = "chrome"
-    else:
-        skip_registry = True
-        chrome = None
+    chromes = ['google-chrome','chrome.exe','chrome']
+    chrome = next((c for c in chromes if distutils.spawn.find_executable(c)), None)
+    skip_registry = True if chrome is None else False
+
 except:
     skip_registry = True
 

--- a/mailbag/derivatives/pdf-chrome.py
+++ b/mailbag/derivatives/pdf-chrome.py
@@ -8,7 +8,9 @@ import mailbag.helper as helper
 
 skip_registry = False
 try:
-    if distutils.spawn.find_executable("chrome.exe"):
+    if distutils.spawn.find_executable("google-chrome"):
+        chrome = "google-chrome"
+    elif distutils.spawn.find_executable("chrome.exe"):
         chrome = "chrome.exe"
     elif distutils.spawn.find_executable("chrome"):
         chrome = "chrome"


### PR DESCRIPTION
 ## Type of Contribution

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New component
- [ ] Refactoring (no functional changes)
- [ ] Documentation-only

## What does this implement/fix? Explain your changes.

Allows PDF derivatives to be created on non-windows systems using the default `google-chrome` command

## Link to issue?

n/a

- [ ] Issue closed
- [ ] Remain open

## Pull Request Checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to the develop branch. Don't PR to main!
- [ ] This contribution has sufficient documentation
- [ ] Tests for the changes have been added
- [ ] All tests pass

#### How has this been tested?
**Operating System:** Ubuntu 20.04
**Python Version:** 3.8.10

## Licensing
- [x] I agree that the Mailbag Project and the University at Albany, SUNY can release this code under the [MIT license](https://github.com/UAlbanyArchives/mailbag/blob/main/LICENSE).
